### PR TITLE
Payments | Code optimization

### DIFF
--- a/backend/payments/apps/base/serializer.py
+++ b/backend/payments/apps/base/serializer.py
@@ -17,3 +17,8 @@ class MoneySerializer(serializers.Serializer):
         decimal_places=2,
     )
     currency = EnumField(choices=EnumCurrencies)
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        representation['currency'] = instance.currency.code
+        return representation

--- a/backend/payments/apps/payment_accounts/serializers.py
+++ b/backend/payments/apps/payment_accounts/serializers.py
@@ -6,6 +6,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from rest_enumfield import EnumField
 from rest_framework import serializers
 
+from ..base.serializer import MoneySerializer
 from .models import Account, BalanceChange, Owner, PayoutData
 
 
@@ -101,15 +102,12 @@ class BalanceSerializer(serializers.ModelSerializer):
 
 
 class PayoutHistorySerializer(serializers.ModelSerializer):
-    sum = serializers.SerializerMethodField()  # noqa: A003
+    sum = MoneySerializer(source='amount')  # noqa: A003
     created_at = serializers.DateTimeField(source='created_date')
 
     class Meta:
         model = BalanceChange
         fields = ('sum', 'created_at')
-
-    def get_sum(self, obj):
-        return {'amount': str(obj.amount.amount), 'currency': obj.amount.currency.code}
 
 
 class OwnerSerializer(serializers.ModelSerializer):

--- a/backend/payments/apps/payment_accounts/views.py
+++ b/backend/payments/apps/payment_accounts/views.py
@@ -175,18 +175,15 @@ class PayoutHistoryPagination(PageNumberPagination):
     max_page_size = 1000
 
 
-class PayoutHistoryView(viewsets.ViewSet):
+class PayoutHistoryView(viewsets.GenericViewSet, mixins.ListModelMixin):
     serializer_class = serializers.PayoutHistorySerializer
-    pagination_class = PayoutHistoryPagination
 
-    def list(self, request, user_uuid=None):  # noqa: A003
+    def get_queryset(self):
+        user_uuid = self.kwargs.get('user_uuid')
         account = get_object_or_404(Account, user_uuid=user_uuid)
         queryset = BalanceChange.objects.filter(
             account_id=account,
             operation_type=BalanceChange.OperationType.WITHDRAW,
             balanceservicemap__operation_type=BalanceServiceMap.OperationType.PAYOUT,
         )
-        paginator = self.pagination_class()
-        page = paginator.paginate_queryset(queryset, request)
-        serializer = self.serializer_class(page, many=True)
-        return Response(serializer.data)
+        return queryset

--- a/backend/payments/apps/payment_accounts/views.py
+++ b/backend/payments/apps/payment_accounts/views.py
@@ -7,7 +7,6 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from rest_framework import mixins, status, viewsets
 from rest_framework.generics import CreateAPIView
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from ..external_payments.models import BalanceServiceMap
@@ -167,12 +166,6 @@ class PayoutDataCreateView(viewsets.ViewSet):
         validated_data['user_uuid'] = developer_account
         serializer.create(validated_data=validated_data)
         return Response(serializer.validated_data, status.HTTP_201_CREATED)
-
-
-class PayoutHistoryPagination(PageNumberPagination):
-    page_size = 50
-    page_size_query_param = 'page_size'
-    max_page_size = 1000
 
 
 class PayoutHistoryView(viewsets.GenericViewSet, mixins.ListModelMixin):


### PR DESCRIPTION
Change:
-base.serializer.py redefined the to_representation method for getting the currency code
-payment_accounts.serializer.py change PayoutHistorySerializer, in the sum field, instead of serializer.Serializer Method Field, we use MoneySerializer
-payment_accounts.views.py change PayoutHistoryView and delete PayoutHistoryPagination